### PR TITLE
Delete broken links during backups

### DIFF
--- a/roles/jenkins/templates/jenkins-backup.sh.j2
+++ b/roles/jenkins/templates/jenkins-backup.sh.j2
@@ -5,6 +5,10 @@ set -u
 BACKUP_DIR="{{ jenkins_backup_directory }}"
 BACKUP_BUCKET="{{ jenkins_backup_bucket }}"
 
+# Thin backups keep failing when we have broken links
+# this attempts to allieviate it
+find /var/lib/jenkins -xtype l -exec rm {} \;
+
 echo "Running backup"
 su - jenkins -c "aws s3 sync --delete --exclude=.initial-sync "$BACKUP_DIR/" "s3://$BACKUP_BUCKET" --quiet 2> /dev/null"
 RV=$?


### PR DESCRIPTION
Thin backups seem to fail with broken links so we can just delete the broken links during backups to help this issue