### PR TITLE
Improve backup script

### DIFF
--- a/roles/jenkins/templates/jenkins-backup.sh.j2
+++ b/roles/jenkins/templates/jenkins-backup.sh.j2
@@ -4,13 +4,15 @@ set -u
 
 BACKUP_DIR="{{ jenkins_backup_directory }}"
 BACKUP_BUCKET="{{ jenkins_backup_bucket }}"
+SYNC_OPTIONS="--delete --exclude=.initial-sync --exclude='*/workspace/*'"
 
 # Thin backups keep failing when we have broken links
 # this attempts to allieviate it
 find /var/lib/jenkins -xtype l -exec rm {} \;
 
 echo "Running backup"
-su - jenkins -c "aws s3 sync --delete --exclude=.initial-sync "$BACKUP_DIR/" "s3://$BACKUP_BUCKET" --quiet 2> /dev/null"
+cd "${BACKUP_DIR}"
+su - jenkins -c "aws s3 sync ${SYNC_OPTIONS} "$BACKUP_DIR/" "s3://$BACKUP_BUCKET" --quiet 2> /dev/null"
 RV=$?
 
 {% if jenkins_backup_dms is defined %}


### PR DESCRIPTION
Some tweaks to the backup script to not include the workspace directory when syncing with s3, this in conjunction with tweaking `thinBackup` will hopefully not cause the backup script to take forever to complete. Fixes #9 