### PR TITLE
Replace deprecated config ing ansible.cfg

### DIFF
--- a/ansible.cfg
+++ b/ansible.cfg
@@ -1,2 +1,2 @@
 [defaults]
-hostfile = hosts
+inventory = hosts


### PR DESCRIPTION
`inventory` should be used instead of `hostfile`
https://docs.ansible.com/ansible/2.4/intro_configuration.html#hostfile