### PR TITLE
chore(nginx): Remove nginx redirect

### DIFF
--- a/roles/nginx/files/nginx.conf
+++ b/roles/nginx/files/nginx.conf
@@ -4,20 +4,8 @@ upstream jenkins {
   server 127.0.0.1:8080 fail_timeout=0;
 }
 
-#server {
-#  listen 80;
-#  return 301 https://$host$request_uri;
-#}
-
 server {
   listen 80;
-
-   # ELB stores the protocol used between the client
-   # and the load balancer in the X-Forwarded-Proto request header.
-   # Check for 'https' and redirect if not
-  if ($http_x_forwarded_proto != 'https') {
-    return 301 https://$host$request_uri;
-  }
 
   location / {
     proxy_pass              http://jenkins;


### PR DESCRIPTION
I want to migrate from ELB to NLB. With NLB we do a ssl termination but do not modify the headers so we can no longer inspect this information. 

I want to migrate to an NLB so that we can have a static IP which we can add to the VPN allow list for Jenkins usage instead of updating the allow list every time the ELB IPs rotate.